### PR TITLE
Add rubygems as gem source to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+source 'https://rubygems.org'
+
 gem 'colorize'
 gem 'json'


### PR DESCRIPTION
During `bundle install`, the Gemfile should have the gem source specified, otherwise there is an error like this:

```
# bundle install
Your Gemfile has no gem server sources. If you need gems that are not already on your machine, add
a line like this to your Gemfile:
source 'https://rubygems.org'
Could not find gem 'colorize' in any of the gem sources listed in your Gemfile.
```